### PR TITLE
Add hello world page showing CompletedTransects count

### DIFF
--- a/app/bones/templates/bones/hello_world.html
+++ b/app/bones/templates/bones/hello_world.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello, world!</title>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    {% if completed_transects_count is not None %}
+    <p>CompletedTransects count: {{ completed_transects_count }}</p>
+    {% else %}
+    <p>CompletedTransects count is currently unavailable.</p>
+    {% endif %}
+  </body>
+</html>

--- a/app/bones/urls.py
+++ b/app/bones/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("", views.hello_world, name="hello_world"),
+]

--- a/app/bones/views.py
+++ b/app/bones/views.py
@@ -1,3 +1,17 @@
 from django.shortcuts import render
+from django.db import DatabaseError
 
-# Create your views here.
+from .models import Completedtransects
+
+
+def hello_world(request):
+    """Render a simple page with the CompletedTransects count."""
+    try:
+        completed_transects_count = Completedtransects.objects.count()
+    except DatabaseError:
+        completed_transects_count = None
+
+    context = {
+        "completed_transects_count": completed_transects_count,
+    }
+    return render(request, "bones/hello_world.html", context)

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'bones',
     #    'allauth',
     #    'allauth.account',
     #    'allauth.socialaccount',

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -21,6 +21,7 @@ from django.urls import path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('bones.urls')),
     #    path('accounts/', include('allauth.urls')),
 ]
 


### PR DESCRIPTION
## Summary
- register the bones app and route the root URL to its views
- add a hello world view that reports the CompletedTransects count and tolerates database issues
- create a simple template to render the greeting and count

## Testing
- `python manage.py check` *(fails: existing models.py contains null bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68d66ea2158c8329aeda9e288c170d81