### PR TITLE
Add dependencies for history and select2 support

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -72,6 +72,9 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.staticfiles',
     'bones',
+    'django_select2',
+    'simple_history',
+    'django_filters',
     #    'allauth',
     #    'allauth.account',
     #    'allauth.socialaccount',
@@ -86,6 +89,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'simple_history.middleware.HistoryRequestMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,6 +6,10 @@ gunicorn==22.0.0
 mssql-django>=1.4
 pyodbc>=4.0
 python-dotenv>=1.0
+# Third-party integrations for history tracking and enhanced widgets
+django-simple-history==3.4.0
+django-select2==7.10.0
+django-filter==23.5
 #certifi==2021.10.8
 #cffi==1.15.0
 #charset-normalizer==2.0.12


### PR DESCRIPTION
## Summary
- add django-simple-history, django-select2, and django-filter dependencies
- register the new apps and middleware in Django settings for history and select2 support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6c47e9648329914eddb3af0dcc97