### PR TITLE
Ensure navigation and dashboard links resolve to real pages

### DIFF
--- a/app/bones/navigation.py
+++ b/app/bones/navigation.py
@@ -2,12 +2,13 @@
 
 This module centralises the primary navigation structure so templates and
 views can rely on a single source of truth. The context processor resolves
-URL names lazily and falls back to ``#`` when routes have not been wired yet,
-which keeps the interface functional during incremental development.
+URL names lazily and falls back to sensible routes (such as child links or the
+dashboard) when targets have not been wired yet, which keeps the interface
+functional during incremental development without exposing broken ``#`` links.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from django.urls import NoReverseMatch, reverse
 
@@ -20,25 +21,51 @@ def _safe_reverse(url_name: Optional[str], *, kwargs: Optional[Mapping[str, Any]
 
     The navigation plan references routes that will come online over the course
     of the coding plan. Swallow ``NoReverseMatch`` errors so placeholder links
-    can gracefully fall back to ``#`` until their corresponding views exist.
+    can gracefully fall back to other working URLs until their corresponding
+    views exist. When an app namespace is omitted the helper automatically
+    retries using the ``bones:`` prefix so callers can pass shorthand route
+    names without breaking links.
     """
     if not url_name:
         return None
 
-    try:
-        return reverse(url_name, kwargs=kwargs)
-    except NoReverseMatch:
-        return None
+    candidate_names = [url_name]
+    if not url_name.startswith("bones:"):
+        candidate_names.append(f"bones:{url_name}")
+
+    for candidate in candidate_names:
+        try:
+            return reverse(candidate, kwargs=kwargs)
+        except NoReverseMatch:
+            continue
+    return None
 
 
 def _materialise_link(link: NavigationLink) -> Dict[str, Any]:
     """Return a link dictionary augmented with a resolved URL."""
+
+    children = [_materialise_link(child) for child in link.get("children", [])]
     resolved_url = link.get("url") or _safe_reverse(link.get("url_name"), kwargs=link.get("kwargs"))
+
+    fallback_sources: Iterable[Optional[str]] = (
+        link.get("fallback_url"),
+        _safe_reverse(link.get("fallback_url_name"), kwargs=link.get("fallback_kwargs")),
+        *[child.get("url") for child in children if child.get("url")],
+        "/",
+    )
+
+    url = resolved_url
+    if not url:
+        for candidate in fallback_sources:
+            if candidate:
+                url = candidate
+                break
+
     return {
         "label": link.get("label", ""),
         "icon": link.get("icon"),
-        "url": resolved_url or link.get("fallback_url", "#"),
-        "children": [_materialise_link(child) for child in link.get("children", [])],
+        "url": url,
+        "children": children,
     }
 
 
@@ -46,80 +73,93 @@ NAVIGATION_SECTIONS: List[NavigationLink] = [
     {
         "label": "Dashboard",
         "icon": "fa-solid fa-gauge-high",
-        "url_name": "dashboard",
+        "url_name": "bones:dashboard",
         "children": [
-            {"label": "Overview", "url_name": "dashboard"},
-            {"label": "Recent Activity", "url_name": "history:dashboard", "fallback_url": "#"},
+            {"label": "Overview", "url_name": "bones:dashboard"},
+            {
+                "label": "Recent Activity",
+                "url_name": "bones:history:index",
+            },
         ],
     },
     {
         "label": "Transects",
         "icon": "fa-solid fa-route",
-        "url_name": "transects:list",
+        "url_name": "bones:transects:list",
         "children": [
-            {"label": "Completed Transects", "url_name": "transects:list"},
-            {"label": "Transect Detail", "url_name": "transects:detail", "fallback_url": "#"},
-            {"label": "Transect History", "url_name": "history:transects"},
+            {"label": "Completed Transects", "url_name": "bones:transects:list"},
+            {
+                "label": "Transect Detail",
+                "url_name": "bones:transects:detail",
+                "fallback_url_name": "bones:transects:list",
+            },
+            {"label": "Transect History", "url_name": "bones:history:transects"},
         ],
     },
     {
         "label": "Occurrences",
         "icon": "fa-solid fa-frog",
-        "url_name": "occurrences:list",
+        "url_name": "bones:occurrences:list",
         "children": [
-            {"label": "Completed Occurrences", "url_name": "occurrences:list"},
-            {"label": "Occurrence Detail", "url_name": "occurrences:detail", "fallback_url": "#"},
-            {"label": "Occurrence History", "url_name": "history:occurrences"},
+            {"label": "Completed Occurrences", "url_name": "bones:occurrences:list"},
+            {
+                "label": "Occurrence Detail",
+                "url_name": "bones:occurrences:detail",
+                "fallback_url_name": "bones:occurrences:list",
+            },
+            {"label": "Occurrence History", "url_name": "bones:history:occurrences"},
         ],
     },
     {
         "label": "Workflows",
         "icon": "fa-solid fa-diagram-project",
-        "url_name": "workflows:list",
+        "url_name": "bones:workflows:list",
         "children": [
-            {"label": "Workflow Runs", "url_name": "workflows:list"},
-            {"label": "Workflow Detail", "url_name": "workflows:detail", "fallback_url": "#"},
-            {"label": "Workflow History", "url_name": "history:workflows"},
+            {"label": "Workflow Runs", "url_name": "bones:workflows:list"},
+            {"label": "Workflow History", "url_name": "bones:history:workflows"},
         ],
     },
     {
         "label": "Templates",
         "icon": "fa-solid fa-layer-group",
-        "url_name": "templates:list",
+        "url_name": "bones:templates:list",
         "children": [
-            {"label": "Template Transects", "url_name": "templates:list"},
-            {"label": "Template Detail", "url_name": "templates:detail", "fallback_url": "#"},
-            {"label": "Template Questions", "url_name": "templates:questions"},
+            {"label": "Template Transects", "url_name": "bones:templates:list"},
+            {"label": "Template Questions", "url_name": "bones:templates:questions"},
         ],
     },
     {
         "label": "Reference Data",
         "icon": "fa-solid fa-database",
-        "url_name": "reference:list",
+        "url_name": "bones:reference:list",
         "children": [
-            {"label": "Data Types", "url_name": "reference:data_types"},
-            {"label": "Data Type Options", "url_name": "reference:data_type_options"},
-            {"label": "Project Config", "url_name": "reference:project_config"},
+            {"label": "Data Types", "url_name": "bones:reference:data_types"},
+            {"label": "Data Type Options", "url_name": "bones:reference:data_type_options"},
+            {"label": "Project Config", "url_name": "bones:reference:project_config"},
         ],
     },
     {
         "label": "Data Logs",
         "icon": "fa-solid fa-file-arrow-down",
-        "url_name": "logs:list",
+        "url_name": "bones:logs:list",
         "children": [
-            {"label": "Uploaded Logs", "url_name": "logs:list"},
-            {"label": "Log Detail", "url_name": "logs:detail", "fallback_url": "#"},
+            {"label": "Uploaded Logs", "url_name": "bones:logs:list"},
+            {
+                "label": "Log Detail",
+                "url_name": "bones:logs:detail",
+                "fallback_url_name": "bones:logs:list",
+            },
         ],
     },
     {
         "label": "History",
         "icon": "fa-solid fa-clock-rotate-left",
-        "url_name": "history:index",
+        "url_name": "bones:history:index",
         "children": [
-            {"label": "Transect History", "url_name": "history:transects"},
-            {"label": "Occurrence History", "url_name": "history:occurrences"},
-            {"label": "Workflow History", "url_name": "history:workflows"},
-            {"label": "Question History", "url_name": "history:questions"},
+            {"label": "Transect History", "url_name": "bones:history:transects"},
+            {"label": "Occurrence History", "url_name": "bones:history:occurrences"},
+            {"label": "Workflow History", "url_name": "bones:history:workflows"},
+            {"label": "Question History", "url_name": "bones:history:questions"},
         ],
     },
 ]

--- a/app/bones/templates/bones/partials/navigation.html
+++ b/app/bones/templates/bones/partials/navigation.html
@@ -8,7 +8,7 @@
     {% if navigation_sections %}
         {% for section in navigation_sections %}
             <div class="w3-dropdown-hover">
-                <a href="{{ section.url|default:'#' }}" class="w3-bar-item w3-button">
+                <a href="{{ section.url|default:'/' }}" class="w3-bar-item w3-button">
                     {% if section.icon %}
                         <span class="fa-fw {{ section.icon }}" aria-hidden="true"></span>
                     {% endif %}
@@ -50,7 +50,7 @@
         </button>
         <div id="bones-mobile-nav" class="w3-bar-block w3-white w3-hide">
             {% for section in navigation_sections %}
-                <a href="{{ section.url|default:'#' }}" class="w3-bar-item w3-button">
+                <a href="{{ section.url|default:'/' }}" class="w3-bar-item w3-button">
                     {% if section.icon %}
                         <span class="fa-fw {{ section.icon }}" aria-hidden="true"></span>
                     {% endif %}

--- a/app/bones/tests/test_dashboard_links.py
+++ b/app/bones/tests/test_dashboard_links.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from unittest.mock import patch
+
+from ..models import CompletedOccurrence, CompletedTransect, DataLogFile
+from ..views.dashboard import DashboardView
+
+
+class _SliceableList(list):
+    """List-like helper that supports ``order_by``/``values`` chains in tests."""
+
+    def order_by(self, *args: Any, **kwargs: Any) -> "_SliceableList":  # pragma: no cover - simple passthrough
+        return self
+
+
+class _ValueList(list):
+    """Emulate Django's ``QuerySet.values()`` return object for slicing."""
+
+    def __getitem__(self, key: Any):  # type: ignore[override]
+        if isinstance(key, slice):
+            return list(super().__getitem__(key))
+        return super().__getitem__(key)
+
+
+class _OrderByStub:
+    """Stub the ``order_by``/``values`` chain used for uploads."""
+
+    def __init__(self, rows: Iterable[dict]):
+        self._rows = list(rows)
+
+    def order_by(self, *args: Any, **kwargs: Any) -> "_OrderByStub":  # pragma: no cover - passthrough
+        return self
+
+    def values(self, *fields: str) -> _ValueList:
+        return _ValueList(
+            [{field: row[field] for field in fields} for row in self._rows]
+        )
+
+
+class DashboardLinkTests(TestCase):
+    def setUp(self) -> None:
+        self.view = DashboardView()
+
+    def test_metric_links_resolve_to_collection_views(self):
+        with patch.object(DashboardView, "_safe_count", side_effect=[1, 2, 3, 0, 0]):
+            metrics = self.view._build_metrics()
+
+        self.assertEqual(metrics[0]["url"], reverse("bones:transects:list"))
+        self.assertEqual(metrics[1]["url"], reverse("bones:occurrences:list"))
+        self.assertEqual(metrics[2]["url"], reverse("bones:workflows:list"))
+        self.assertEqual(metrics[3]["url"], reverse("bones:workflows:list"))
+
+    def test_quick_links_point_to_operational_pages(self):
+        links = self.view._build_quick_links(pending_audits=5, history_count=3)
+
+        self.assertEqual(links[0]["url"], reverse("bones:transects:list"))
+        self.assertEqual(links[1]["url"], reverse("bones:history:index"))
+
+    def test_recent_transects_link_to_detail_pages(self):
+        transect = SimpleNamespace(
+            pk=11,
+            name="Transect 11",
+            start_time=timezone.now(),
+            state="completed",
+        )
+        queryset = _SliceableList([transect])
+
+        with patch.object(CompletedTransect.objects, "for_dashboard", return_value=queryset):
+            results = self.view._fetch_recent_transects()
+
+        self.assertEqual(
+            results[0]["url"],
+            reverse("bones:transects:detail", kwargs={"pk": transect.pk}),
+        )
+
+    def test_recent_occurrences_link_to_detail_pages(self):
+        occurrence = SimpleNamespace(
+            pk=7,
+            occurrence_number=7,
+            transect=SimpleNamespace(name="Evening Survey"),
+            state="verified",
+        )
+        queryset = _SliceableList([occurrence])
+
+        with patch.object(
+            CompletedOccurrence.objects,
+            "with_related_data",
+            return_value=queryset,
+        ):
+            results = self.view._fetch_recent_occurrences()
+
+        self.assertEqual(
+            results[0]["url"],
+            reverse("bones:occurrences:detail", kwargs={"pk": occurrence.pk}),
+        )
+
+    def test_recent_uploads_link_to_log_detail(self):
+        upload = {
+            "id": 5,
+            "upload_date": timezone.now(),
+            "uploaded_by": "Lead Scientist",
+        }
+
+        with patch.object(
+            DataLogFile.objects,
+            "order_by",
+            return_value=_OrderByStub([upload]),
+        ):
+            uploads = self.view._fetch_recent_uploads()
+
+        self.assertEqual(
+            uploads[0]["url"],
+            reverse("bones:logs:detail", kwargs={"pk": upload["id"]}),
+        )

--- a/app/bones/tests/test_navigation.py
+++ b/app/bones/tests/test_navigation.py
@@ -1,9 +1,22 @@
 from django.test import SimpleTestCase
+from django.urls import reverse
 
 from ..navigation import _materialise_link, navigation_context
 
 
 class NavigationContextTests(SimpleTestCase):
+    def _find_link(self, label: str):
+        context = navigation_context(object())
+        sections = context["navigation_sections"]
+
+        for section in sections:
+            if section.get("label") == label:
+                return section
+            for child in section.get("children", []):
+                if child.get("label") == label:
+                    return child
+        self.fail(f"Navigation link with label '{label}' was not found")
+
     def test_navigation_context_provides_sections(self):
         context = navigation_context(object())
         sections = context["navigation_sections"]
@@ -20,8 +33,31 @@ class NavigationContextTests(SimpleTestCase):
                 "label": "Example",
                 "icon": "fa-solid fa-circle-info",
                 "fallback_url": "/placeholder/",
-                "children": [{"label": "Child", "fallback_url": "#"}],
+                "children": [{"label": "Child", "fallback_url": "/child/"}],
             }
         )
         self.assertEqual(link["url"], "/placeholder/")
-        self.assertEqual(link["children"][0]["url"], "#")
+        self.assertEqual(link["children"][0]["url"], "/child/")
+
+    def test_materialise_link_uses_descendant_when_no_direct_fallback(self):
+        link = _materialise_link(
+            {
+                "label": "Parent",
+                "children": [
+                    {
+                        "label": "Child",
+                        "url": "/child/",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(link["url"], "/child/")
+
+    def test_completed_transects_link_points_to_list_view(self):
+        link = self._find_link("Completed Transects")
+        self.assertEqual(link["url"], reverse("bones:transects:list"))
+
+    def test_completed_occurrences_link_points_to_list_view(self):
+        link = self._find_link("Completed Occurrences")
+        self.assertEqual(link["url"], reverse("bones:occurrences:list"))

--- a/app/bones/views/detail.py
+++ b/app/bones/views/detail.py
@@ -22,17 +22,28 @@ EM_DASH = "\u2014"
 
 
 def safe_reverse(name: str | None, *, kwargs: Mapping[str, Any] | None = None) -> str | None:
-    """Resolve a URL name if it exists, otherwise return ``None``."""
+    """Resolve a URL name if it exists, otherwise return ``None``.
+
+    Callers can provide either fully qualified names (``bones:app:view``) or
+    the legacy shorthand without the app namespace. The helper attempts both so
+    templates remain stable while URL wiring is refined.
+    """
 
     if not name:
         return None
 
-    try:
-        if kwargs:
-            return reverse(name, kwargs=kwargs)
-        return reverse(name)
-    except NoReverseMatch:
-        return None
+    candidate_names = [name]
+    if not name.startswith("bones:"):
+        candidate_names.append(f"bones:{name}")
+
+    for candidate in candidate_names:
+        try:
+            if kwargs:
+                return reverse(candidate, kwargs=kwargs)
+            return reverse(candidate)
+        except NoReverseMatch:
+            continue
+    return None
 
 
 def format_value(value: Any) -> str:

--- a/app/bones/views/history.py
+++ b/app/bones/views/history.py
@@ -40,25 +40,25 @@ class HistoryIndexView(BonesAuthMixin, TemplateView):
                 label=_("Transects"),
                 description=_("Review audit history captured for completed transects."),
                 icon="fa-solid fa-route",
-                url=safe_reverse("history:transects"),
+                url=safe_reverse("bones:history:transects"),
             ),
             HistoryLink(
                 label=_("Occurrences"),
                 description=_("Inspect changes made to completed occurrences."),
                 icon="fa-solid fa-frog",
-                url=safe_reverse("history:occurrences"),
+                url=safe_reverse("bones:history:occurrences"),
             ),
             HistoryLink(
                 label=_("Workflows"),
                 description=_("Track workflow status changes across completed runs."),
                 icon="fa-solid fa-diagram-project",
-                url=safe_reverse("history:workflows"),
+                url=safe_reverse("bones:history:workflows"),
             ),
             HistoryLink(
                 label=_("Questions"),
                 description=_("Audit updates to survey questions and configuration."),
                 icon="fa-solid fa-circle-question",
-                url=safe_reverse("history:questions"),
+                url=safe_reverse("bones:history:questions"),
             ),
         ]
 
@@ -179,7 +179,7 @@ class HistoryBaseMixin(BonesAuthMixin):
     def build_breadcrumbs(self) -> List[dict[str, Optional[str]]]:
         return [
             {"label": _("Dashboard"), "url": safe_reverse("dashboard")},
-            {"label": _("History"), "url": safe_reverse("history:index")},
+            {"label": _("History"), "url": safe_reverse("bones:history:index")},
             {"label": self.entity_plural_label, "url": safe_reverse(self.list_route_name)},
         ]
 

--- a/app/bones/views/lists.py
+++ b/app/bones/views/lists.py
@@ -40,17 +40,27 @@ EM_DASH = "\u2014"
 
 
 def safe_reverse(name: str | None, *, kwargs: dict[str, object] | None = None) -> str | None:
-    """Resolve a URL name when available, otherwise return ``None``."""
+    """Resolve a URL name when available, otherwise return ``None``.
+
+    Accepts both fully-qualified ``bones:`` names and shorthand references to
+    keep legacy list views working while URLs are consolidated.
+    """
 
     if not name:
         return None
 
-    try:
-        if kwargs:
-            return reverse(name, kwargs=kwargs)
-        return reverse(name)
-    except NoReverseMatch:
-        return None
+    candidate_names = [name]
+    if not name.startswith("bones:"):
+        candidate_names.append(f"bones:{name}")
+
+    for candidate in candidate_names:
+        try:
+            if kwargs:
+                return reverse(candidate, kwargs=kwargs)
+            return reverse(candidate)
+        except NoReverseMatch:
+            continue
+    return None
 
 
 def format_datetime(value):

--- a/app/bones/views/master_detail.py
+++ b/app/bones/views/master_detail.py
@@ -118,8 +118,8 @@ class CompletedTransectDetailView(BonesMasterDetailView):
     intro_text = _(
         "Inspect a completed transect, review its captured occurrences, track points, and audit history."
     )
-    list_route_name = "transects:list"
-    history_route_name = "history:transect_record"
+    list_route_name = "bones:transects:list"
+    history_route_name = "bones:history:transect_record"
     breadcrumb_list_label = _("Completed transects")
     tablist_label = _("Transect detail navigation")
 
@@ -139,12 +139,12 @@ class CompletedTransectDetailView(BonesMasterDetailView):
             {
                 "label": _("Export responses"),
                 "icon": "fa-solid fa-file-export",
-                "url": safe_reverse("transects:export_responses", kwargs={"pk": obj.pk}),
+                "url": safe_reverse("bones:transects:export_responses", kwargs={"pk": obj.pk}),
             },
             {
                 "label": _("Download GPS track"),
                 "icon": "fa-solid fa-download",
-                "url": safe_reverse("transects:download_track", kwargs={"pk": obj.pk}),
+                "url": safe_reverse("bones:transects:download_track", kwargs={"pk": obj.pk}),
             },
         ]
 
@@ -342,8 +342,8 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
     intro_text = _(
         "Review a recorded occurrence, browse captured responses, linked workflows, and audit events."
     )
-    list_route_name = "occurrences:list"
-    history_route_name = "history:occurrence_record"
+    list_route_name = "bones:occurrences:list"
+    history_route_name = "bones:history:occurrence_record"
     breadcrumb_list_label = _("Completed occurrences")
     tablist_label = _("Occurrence detail navigation")
 


### PR DESCRIPTION
## Summary
- namespace navigation entries and add automatic `bones:` prefix handling so menu links resolve to working routes
- point dashboard metrics, quick links, and recent activity lists at the live list/detail URLs and extend helper fallbacks
- cover the behaviour with new navigation and dashboard link tests to prevent regressions

## Testing
- python app/manage.py test bones.tests.test_navigation bones.tests.test_dashboard_links

------
https://chatgpt.com/codex/tasks/task_e_68dbd4265c008329b12b77d3f7177388