### PR TITLE
Adjust detail metadata layout for summary views

### DIFF
--- a/app/bones/templates/bones/partials/detail_metadata.html
+++ b/app/bones/templates/bones/partials/detail_metadata.html
@@ -16,8 +16,8 @@
             <dl class="w3-margin-0">
                 {% for item in section.items %}
                     <div class="w3-row w3-margin-bottom">
-                        <dt class="w3-col s12 m4 l4 w3-text-grey">{{ item.label }}</dt>
-                        <dd class="w3-col s12 m8 l8 w3-margin-0">{{ item.value|safe }}</dd>
+                        <dt class="w3-col s5 m4 l4 w3-text-grey">{{ item.label }}</dt>
+                        <dd class="w3-col s7 m8 l8 w3-margin-0">{{ item.value|safe }}</dd>
                     </div>
                 {% endfor %}
             </dl>


### PR DESCRIPTION
## Summary
- update the shared detail metadata partial so labels remain on the left and values on the right on all breakpoints
- ensure summary sections in occurrence detail pages display information in a more table-like layout for improved space usage

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd0b6bed788329a9d0c78f032e4738