### PR TITLE
Implement vertical pagination component

### DIFF
--- a/app/bones/templates/bones/partials/pagination.html
+++ b/app/bones/templates/bones/partials/pagination.html
@@ -1,41 +1,73 @@
 {# Accessible pagination controls that preserve active filters. #}
+{% load pagination_tags %}
 {% if is_paginated %}
     <nav class="w3-margin-top" aria-label="Pagination">
-        <ul class="w3-pagination w3-border w3-round-large">
+        <ul class="w3-ul w3-border w3-round-large w3-white">
             {% with qs=filter_querystring %}
                 <li>
                     {% if page_obj.has_previous %}
-                        <a class="w3-button" href="?page=1{{ qs }}" aria-label="First page">&laquo;</a>
+                        <a class="w3-button w3-block w3-left-align" href="?page=1{{ qs }}" aria-label="First page">
+                            <span aria-hidden="true">&laquo;</span>
+                            <span class="w3-margin-left">First</span>
+                        </a>
                     {% else %}
-                        <span class="w3-button w3-disabled" aria-hidden="true">&laquo;</span>
+                        <span class="w3-button w3-block w3-left-align w3-disabled" aria-disabled="true">
+                            <span aria-hidden="true">&laquo;</span>
+                            <span class="w3-margin-left">First</span>
+                        </span>
                     {% endif %}
                 </li>
                 <li>
                     {% if page_obj.has_previous %}
-                        <a class="w3-button" href="?page={{ page_obj.previous_page_number }}{{ qs }}" aria-label="Previous page">&lsaquo;</a>
+                        <a class="w3-button w3-block w3-left-align" href="?page={{ page_obj.previous_page_number }}{{ qs }}" aria-label="Previous page">
+                            <span aria-hidden="true">&lsaquo;</span>
+                            <span class="w3-margin-left">Previous</span>
+                        </a>
                     {% else %}
-                        <span class="w3-button w3-disabled" aria-hidden="true">&lsaquo;</span>
+                        <span class="w3-button w3-block w3-left-align w3-disabled" aria-disabled="true">
+                            <span aria-hidden="true">&lsaquo;</span>
+                            <span class="w3-margin-left">Previous</span>
+                        </span>
                     {% endif %}
                 </li>
-                {% for num in page_obj.paginator.page_range %}
-                    {% if num == page_obj.number %}
-                        <li><span class="w3-button w3-blue" aria-current="page">{{ num }}</span></li>
-                    {% else %}
-                        <li><a class="w3-button" href="?page={{ num }}{{ qs }}">{{ num }}</a></li>
-                    {% endif %}
+                {% compact_page_range page_obj 3 as page_numbers %}
+                {% for num in page_numbers %}
+                    <li>
+                        {% if num == page_obj.number %}
+                            <span class="w3-button w3-block w3-left-align w3-blue" aria-current="page">
+                                <span class="w3-margin-right">Page</span>{{ num }}
+                            </span>
+                        {% else %}
+                            <a class="w3-button w3-block w3-left-align" href="?page={{ num }}{{ qs }}" aria-label="Go to page {{ num }}">
+                                <span class="w3-margin-right">Page</span>{{ num }}
+                            </a>
+                        {% endif %}
+                    </li>
                 {% endfor %}
                 <li>
                     {% if page_obj.has_next %}
-                        <a class="w3-button" href="?page={{ page_obj.next_page_number }}{{ qs }}" aria-label="Next page">&rsaquo;</a>
+                        <a class="w3-button w3-block w3-left-align" href="?page={{ page_obj.next_page_number }}{{ qs }}" aria-label="Next page">
+                            <span aria-hidden="true">&rsaquo;</span>
+                            <span class="w3-margin-left">Next</span>
+                        </a>
                     {% else %}
-                        <span class="w3-button w3-disabled" aria-hidden="true">&rsaquo;</span>
+                        <span class="w3-button w3-block w3-left-align w3-disabled" aria-disabled="true">
+                            <span aria-hidden="true">&rsaquo;</span>
+                            <span class="w3-margin-left">Next</span>
+                        </span>
                     {% endif %}
                 </li>
                 <li>
                     {% if page_obj.has_next %}
-                        <a class="w3-button" href="?page={{ page_obj.paginator.num_pages }}{{ qs }}" aria-label="Last page">&raquo;</a>
+                        <a class="w3-button w3-block w3-left-align" href="?page={{ page_obj.paginator.num_pages }}{{ qs }}" aria-label="Last page">
+                            <span aria-hidden="true">&raquo;</span>
+                            <span class="w3-margin-left">Last</span>
+                        </a>
                     {% else %}
-                        <span class="w3-button w3-disabled" aria-hidden="true">&raquo;</span>
+                        <span class="w3-button w3-block w3-left-align w3-disabled" aria-disabled="true">
+                            <span aria-hidden="true">&raquo;</span>
+                            <span class="w3-margin-left">Last</span>
+                        </span>
                     {% endif %}
                 </li>
             {% endwith %}

--- a/app/bones/templatetags/__init__.py
+++ b/app/bones/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Templatetag package for bones app."""

--- a/app/bones/templatetags/pagination_tags.py
+++ b/app/bones/templatetags/pagination_tags.py
@@ -1,0 +1,42 @@
+"""Custom template tags to assist with pagination rendering."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def compact_page_range(page_obj, max_length: int = 3) -> Iterable[int]:
+    """Return a compact range of page numbers centered on the current page.
+
+    The range includes at most ``max_length`` numbers, favors centering the
+    current page when possible, and gracefully handles small collections.
+    """
+
+    total_pages = getattr(page_obj, "paginator").num_pages
+    current = getattr(page_obj, "number")
+    window = max(1, int(max_length))
+
+    if total_pages <= window:
+        start = 1
+        end = total_pages
+    else:
+        half_window = window // 2
+        start = current - half_window
+        end = current + half_window
+
+        if window % 2 == 0:
+            end -= 1
+
+        if start < 1:
+            start = 1
+            end = window
+        elif end > total_pages:
+            end = total_pages
+            start = total_pages - window + 1
+
+    return range(start, end + 1)

--- a/app/bones/tests/test_templatetags.py
+++ b/app/bones/tests/test_templatetags.py
@@ -1,0 +1,27 @@
+import unittest
+
+from django.core.paginator import Paginator
+
+from ..templatetags.pagination_tags import compact_page_range
+
+
+class CompactPageRangeTests(unittest.TestCase):
+    def _build_page(self, total_items, per_page, number):
+        paginator = Paginator(range(total_items), per_page)
+        return paginator.page(number)
+
+    def test_returns_all_pages_when_total_below_window(self):
+        page = self._build_page(total_items=5, per_page=5, number=1)
+        self.assertEqual(list(compact_page_range(page, max_length=3)), [1])
+
+    def test_centers_current_page_when_possible(self):
+        page = self._build_page(total_items=50, per_page=5, number=5)
+        self.assertEqual(list(compact_page_range(page, max_length=3)), [4, 5, 6])
+
+    def test_shifts_window_to_start_when_near_beginning(self):
+        page = self._build_page(total_items=50, per_page=5, number=1)
+        self.assertEqual(list(compact_page_range(page, max_length=3)), [1, 2, 3])
+
+    def test_shifts_window_to_end_when_near_finish(self):
+        page = self._build_page(total_items=50, per_page=5, number=10)
+        self.assertEqual(list(compact_page_range(page, max_length=3)), [8, 9, 10])


### PR DESCRIPTION
## Summary
- add a reusable `compact_page_range` template tag to limit pagination page numbers
- switch the pagination partial to a vertical W3.CSS list with labeled first/prev/next/last controls

## Testing
- pytest app/bones/tests/test_templatetags.py

------
https://chatgpt.com/codex/tasks/task_e_68dd123547248329a33dc510f1688be5