### PR TITLE
Add indexes for CompletedTransects filters

### DIFF
--- a/app/bones/migrations/0002_completedtransect_indexes.py
+++ b/app/bones/migrations/0002_completedtransect_indexes.py
@@ -1,0 +1,90 @@
+from django.db import migrations
+
+
+CREATE_TEMPLATE_START = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedTransects_Template_StartTime'
+      AND object_id = OBJECT_ID('CompletedTransects')
+)
+BEGIN
+    CREATE INDEX IX_CompletedTransects_Template_StartTime
+        ON CompletedTransects ([TransectTemplateID] ASC, [start_time] DESC);
+END
+"""
+
+DROP_TEMPLATE_START = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedTransects_Template_StartTime'
+      AND object_id = OBJECT_ID('CompletedTransects')
+)
+BEGIN
+    DROP INDEX IX_CompletedTransects_Template_StartTime ON CompletedTransects;
+END
+"""
+
+CREATE_STATE = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedTransects_State'
+      AND object_id = OBJECT_ID('CompletedTransects')
+)
+BEGIN
+    CREATE INDEX IX_CompletedTransects_State
+        ON CompletedTransects ([state]);
+END
+"""
+
+DROP_STATE = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedTransects_State'
+      AND object_id = OBJECT_ID('CompletedTransects')
+)
+BEGIN
+    DROP INDEX IX_CompletedTransects_State ON CompletedTransects;
+END
+"""
+
+CREATE_END_TIME = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedTransects_EndTime'
+      AND object_id = OBJECT_ID('CompletedTransects')
+)
+BEGIN
+    CREATE INDEX IX_CompletedTransects_EndTime
+        ON CompletedTransects ([end_time] DESC);
+END
+"""
+
+DROP_END_TIME = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedTransects_EndTime'
+      AND object_id = OBJECT_ID('CompletedTransects')
+)
+BEGIN
+    DROP INDEX IX_CompletedTransects_EndTime ON CompletedTransects;
+END
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bones", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunSQL(CREATE_TEMPLATE_START, DROP_TEMPLATE_START),
+        migrations.RunSQL(CREATE_STATE, DROP_STATE),
+        migrations.RunSQL(CREATE_END_TIME, DROP_END_TIME),
+    ]


### PR DESCRIPTION
## Summary
- add a migration that creates supporting SQL Server indexes for common CompletedTransects filters
- guard each index creation with existence checks so deployments can run repeatedly

## Testing
- not run (database not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd21922a508329bc08dc2a46da0c25