### PR TITLE
Add SQL Server indexes for CompletedOccurrences queries

### DIFF
--- a/app/bones/migrations/0003_completedoccurrence_indexes.py
+++ b/app/bones/migrations/0003_completedoccurrence_indexes.py
@@ -1,0 +1,116 @@
+from django.db import migrations
+
+
+CREATE_TRANSECT_START = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_Transect_StartTime'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    CREATE INDEX IX_CompletedOccurrences_Transect_StartTime
+        ON CompletedOccurrences ([TransectUID] ASC, [RecordingStartTime] DESC);
+END
+"""
+
+DROP_TRANSECT_START = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_Transect_StartTime'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    DROP INDEX IX_CompletedOccurrences_Transect_StartTime ON CompletedOccurrences;
+END
+"""
+
+CREATE_END_TIME = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_EndTime'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    CREATE INDEX IX_CompletedOccurrences_EndTime
+        ON CompletedOccurrences ([RecordingEndTime] DESC);
+END
+"""
+
+DROP_END_TIME = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_EndTime'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    DROP INDEX IX_CompletedOccurrences_EndTime ON CompletedOccurrences;
+END
+"""
+
+CREATE_STATE = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_State'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    CREATE INDEX IX_CompletedOccurrences_State
+        ON CompletedOccurrences ([State]);
+END
+"""
+
+DROP_STATE = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_State'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    DROP INDEX IX_CompletedOccurrences_State ON CompletedOccurrences;
+END
+"""
+
+CREATE_OCCURRENCE_NUMBER = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_OccurrenceNumber'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    CREATE INDEX IX_CompletedOccurrences_OccurrenceNumber
+        ON CompletedOccurrences ([OccurrenceNumber]);
+END
+"""
+
+DROP_OCCURRENCE_NUMBER = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedOccurrences_OccurrenceNumber'
+      AND object_id = OBJECT_ID('CompletedOccurrences')
+)
+BEGIN
+    DROP INDEX IX_CompletedOccurrences_OccurrenceNumber ON CompletedOccurrences;
+END
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bones", "0002_completedtransect_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(CREATE_TRANSECT_START, DROP_TRANSECT_START),
+        migrations.RunSQL(CREATE_END_TIME, DROP_END_TIME),
+        migrations.RunSQL(CREATE_STATE, DROP_STATE),
+        migrations.RunSQL(CREATE_OCCURRENCE_NUMBER, DROP_OCCURRENCE_NUMBER),
+    ]


### PR DESCRIPTION
## Summary
- add guard-railed SQL Server index creation statements for CompletedOccurrences filtering needs
- cover default ordering/filter combo, end-time filter, state filter, and optional occurrence lookups with dedicated indexes

## Testing
- not run (database environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd232344c0832984fea214e4add2eb