### PR TITLE
Add indexes for CompletedWorkflows lookups

### DIFF
--- a/app/bones/migrations/0004_completedworkflow_indexes.py
+++ b/app/bones/migrations/0004_completedworkflow_indexes.py
@@ -1,0 +1,64 @@
+from django.db import migrations
+
+
+CREATE_OCCURRENCE_INSTANCE = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedWorkflows_Occurrence_InstanceNumber'
+      AND object_id = OBJECT_ID('CompletedWorkflows')
+)
+BEGIN
+    CREATE INDEX IX_CompletedWorkflows_Occurrence_InstanceNumber
+        ON CompletedWorkflows ([OccurrenceID] ASC, [InstanceNumber] DESC);
+END
+"""
+
+DROP_OCCURRENCE_INSTANCE = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedWorkflows_Occurrence_InstanceNumber'
+      AND object_id = OBJECT_ID('CompletedWorkflows')
+)
+BEGIN
+    DROP INDEX IX_CompletedWorkflows_Occurrence_InstanceNumber ON CompletedWorkflows;
+END
+"""
+
+CREATE_TEMPLATE = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedWorkflows_TemplateWorkflow'
+      AND object_id = OBJECT_ID('CompletedWorkflows')
+)
+BEGIN
+    CREATE INDEX IX_CompletedWorkflows_TemplateWorkflow
+        ON CompletedWorkflows ([TemplateWorkflowID]);
+END
+"""
+
+DROP_TEMPLATE = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_CompletedWorkflows_TemplateWorkflow'
+      AND object_id = OBJECT_ID('CompletedWorkflows')
+)
+BEGIN
+    DROP INDEX IX_CompletedWorkflows_TemplateWorkflow ON CompletedWorkflows;
+END
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bones", "0003_completedoccurrence_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(CREATE_OCCURRENCE_INSTANCE, DROP_OCCURRENCE_INSTANCE),
+        migrations.RunSQL(CREATE_TEMPLATE, DROP_TEMPLATE),
+    ]


### PR DESCRIPTION
## Summary
- add a migration that creates SQL Server indexes for the CompletedWorkflows table
- cover occurrence ordering with an index on OccurrenceID and InstanceNumber DESC and template filtering with TemplateWorkflowID

## Testing
- not run (SQL Server database unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd24781a648329bf3e7b879cff2ebf