### PR TITLE
Add TemplateTransects scheduled time index and coverage tests

### DIFF
--- a/app/bones/migrations/0005_templatetransect_indexes.py
+++ b/app/bones/migrations/0005_templatetransect_indexes.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+
+CREATE_SCHEDULED_TIME_INDEX = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_TemplateTransects_ScheduledTime'
+      AND object_id = OBJECT_ID('TemplateTransects')
+)
+BEGIN
+    CREATE INDEX IX_TemplateTransects_ScheduledTime
+        ON TemplateTransects ([Scheduled_time] DESC);
+END
+"""
+
+DROP_SCHEDULED_TIME_INDEX = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_TemplateTransects_ScheduledTime'
+      AND object_id = OBJECT_ID('TemplateTransects')
+)
+BEGIN
+    DROP INDEX IX_TemplateTransects_ScheduledTime ON TemplateTransects;
+END
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bones", "0004_completedworkflow_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            CREATE_SCHEDULED_TIME_INDEX,
+            DROP_SCHEDULED_TIME_INDEX,
+        ),
+    ]

--- a/app/bones/tests/test_filters.py
+++ b/app/bones/tests/test_filters.py
@@ -8,9 +8,10 @@ from django.views.generic import ListView
 
 from ..filters import (
     FilteredListViewMixin,
+    TemplateTransectFilterSet,
     _state_choices,
 )
-from ..models import CompletedTransect
+from ..models import CompletedTransect, TemplateTransect
 
 
 class DummyFilterSet(django_filters.FilterSet):
@@ -90,3 +91,17 @@ class FilteredListViewMixinTests(SimpleTestCase):
         view.setup(request)
         with self.assertRaises(ImproperlyConfigured):
             view.get_queryset()
+
+
+class TemplateTransectFilterSetTests(SimpleTestCase):
+    def test_scheduling_filters_target_indexed_column(self):
+        queryset = TemplateTransect.objects.none()
+        filterset = TemplateTransectFilterSet(data={}, queryset=queryset)
+
+        scheduled_after = filterset.filters["scheduled_after"]
+        scheduled_before = filterset.filters["scheduled_before"]
+
+        self.assertEqual(scheduled_after.field_name, "scheduled_time")
+        self.assertEqual(scheduled_before.field_name, "scheduled_time")
+        self.assertEqual(scheduled_after.lookup_expr, "gte")
+        self.assertEqual(scheduled_before.lookup_expr, "lte")

--- a/app/bones/tests/test_views_lists.py
+++ b/app/bones/tests/test_views_lists.py
@@ -1,10 +1,11 @@
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import django_filters
 from django.test import RequestFactory, SimpleTestCase
 
-from ..models import CompletedTransect
-from ..views.lists import BonesListView
+from ..models import CompletedTransect, TemplateTransect
+from ..views.lists import BonesListView, TemplateTransectListView
 
 
 class DummyFilterSet(django_filters.FilterSet):
@@ -65,3 +66,36 @@ class BonesListViewTests(SimpleTestCase):
         history_url = view.get_history_url(obj)
         self.assertIsNone(detail_url)
         self.assertIsNone(history_url)
+
+
+class TemplateTransectListViewTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = SimpleNamespace(
+            is_authenticated=True,
+            has_perms=lambda perms: True,
+        )
+
+    @patch("app.bones.views.lists.TemplateTransectFilterSet")
+    @patch("app.bones.views.lists.TemplateTransect.objects")
+    def test_queryset_orders_by_descending_scheduled_time(
+        self, mock_manager, mock_filterset
+    ):
+        request = self.factory.get("/templates/transects/")
+        request.user = self.user
+
+        ordered_queryset = MagicMock(name="OrderedQuerySet")
+        ordered_queryset.model = TemplateTransect
+        mock_manager.order_by.return_value = ordered_queryset
+
+        filter_instance = mock_filterset.return_value
+        filter_instance.form = MagicMock()
+        filter_instance.qs = ordered_queryset
+
+        view = TemplateTransectListView()
+        view.setup(request)
+        queryset = view.get_queryset()
+
+        mock_manager.order_by.assert_called_once_with("-scheduled_time")
+        mock_filterset.assert_called_once_with(data={}, queryset=ordered_queryset)
+        self.assertIs(queryset, ordered_queryset)


### PR DESCRIPTION
## Summary
- ensure the TemplateTransects table has a descending Scheduled_time index via a guarded RunSQL migration
- exercise the template transect filter set to confirm the before/after controls target the Scheduled_time column
- verify the template transect list view orders by Scheduled_time so the new index can support the queryset

## Testing
- pytest *(fails: requires DJANGO_SETTINGS_MODULE configuration in this environment)*
- python manage.py test *(fails on SQLite because the guarded SQL Server index creation syntax is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68dd25afc98483299f4db9c2721b54f7