### PR TITLE
Add SQL Server indexes for question filters and ordering

### DIFF
--- a/app/bones/migrations/0006_question_indexes.py
+++ b/app/bones/migrations/0006_question_indexes.py
@@ -1,0 +1,98 @@
+"""Add indexes that support question list ordering and select2 filters."""
+
+from django.db import migrations
+
+
+CREATE_WORKFLOW_ID = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_Questions_WorkflowID'
+      AND object_id = OBJECT_ID('Questions')
+)
+BEGIN
+    CREATE INDEX IX_Questions_WorkflowID
+        ON Questions ([WorkflowID]);
+END
+"""
+
+
+DROP_WORKFLOW_ID = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_Questions_WorkflowID'
+      AND object_id = OBJECT_ID('Questions')
+)
+BEGIN
+    DROP INDEX IX_Questions_WorkflowID ON Questions;
+END
+"""
+
+
+CREATE_DATA_TYPE_ID = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_Questions_DataTypeID'
+      AND object_id = OBJECT_ID('Questions')
+)
+BEGIN
+    CREATE INDEX IX_Questions_DataTypeID
+        ON Questions ([DataTypeID]);
+END
+"""
+
+
+DROP_DATA_TYPE_ID = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_Questions_DataTypeID'
+      AND object_id = OBJECT_ID('Questions')
+)
+BEGIN
+    DROP INDEX IX_Questions_DataTypeID ON Questions;
+END
+"""
+
+
+CREATE_PROMPT = """
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_Questions_Prompt'
+      AND object_id = OBJECT_ID('Questions')
+)
+BEGIN
+    CREATE INDEX IX_Questions_Prompt
+        ON Questions ([Prompt] ASC);
+END
+"""
+
+
+DROP_PROMPT = """
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = 'IX_Questions_Prompt'
+      AND object_id = OBJECT_ID('Questions')
+)
+BEGIN
+    DROP INDEX IX_Questions_Prompt ON Questions;
+END
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bones", "0005_templatetransect_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(CREATE_WORKFLOW_ID, DROP_WORKFLOW_ID),
+        migrations.RunSQL(CREATE_DATA_TYPE_ID, DROP_DATA_TYPE_ID),
+        migrations.RunSQL(CREATE_PROMPT, DROP_PROMPT),
+    ]
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,17 @@ widgets, and history timelines.
   breadcrumbs so users can review change metadata alongside the related records
   and navigation actions.
 
+## Database indexes
+
+* SQL Server runs with unmanaged tables, so performance-sensitive indexes are
+  maintained through raw `RunSQL` migrations under `app/bones/migrations/`.
+* The questions list and select2 widgets previously scanned the `Questions`
+  table when filtering by workflow or data type, or when ordering prompts.
+  Migration `0006_question_indexes` adds nonclustered indexes on `WorkflowID`
+  and `DataTypeID` to accelerate the select2 filters used by
+  `QuestionFilterSet`, and creates an index on `Prompt` to support the
+  alphabetical ordering defined in `QuestionListView`.
+
 ## Static assets and styling
 
 * `templates/bones/base.html` loads W3.CSS, Font Awesome, and the project’s


### PR DESCRIPTION
## Summary
- audit and document the Questions table indexes used by question list and select2 filters
- add a SQL Server migration that creates nonclustered indexes on WorkflowID, DataTypeID, and Prompt for the Questions table

## Testing
- pytest *(fails: settings module is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd271a9c508329b2c9a7892e74ef60