### PR TITLE
Add instance summaries to completed occurrence detail view

### DIFF
--- a/app/bones/templates/bones/completed_occurrences/_related.html
+++ b/app/bones/templates/bones/completed_occurrences/_related.html
@@ -1,21 +1,28 @@
 {% load i18n %}
-<section class="w3-section">
-    <header class="w3-margin-bottom">
-        <h3 class="w3-large w3-margin-0">
-            <span class="fa-fw fa-solid fa-list-check" aria-hidden="true"></span>
-            {% trans "Responses" %}
-        </h3>
-        <p class="w3-text-grey">{% trans "All responses collected for this occurrence." %}</p>
-    </header>
-    {% include "bones/partials/table.html" with table_headers=occurrence_response_headers table_rows=occurrence_response_rows table_caption=_('Occurrence responses') %}
-</section>
-<section class="w3-section">
-    <header class="w3-margin-bottom">
-        <h3 class="w3-large w3-margin-0">
-            <span class="fa-fw fa-solid fa-diagram-project" aria-hidden="true"></span>
-            {% trans "Workflows" %}
-        </h3>
-        <p class="w3-text-grey">{% trans "Completed workflows linked to this occurrence." %}</p>
-    </header>
-    {% include "bones/partials/table.html" with table_headers=occurrence_workflow_headers table_rows=occurrence_workflow_rows table_caption=_('Occurrence workflows') %}
-</section>
+{% if occurrence_instances %}
+    {% for instance in occurrence_instances %}
+        <section class="w3-section">
+            <header class="w3-margin-bottom">
+                <h3 class="w3-large w3-margin-0">
+                    <span class="fa-fw fa-solid fa-layer-group" aria-hidden="true"></span>
+                    {% blocktrans trimmed with number=instance.display_number %}Instance {{ number }}{% endblocktrans %}
+                </h3>
+                {% if instance.url %}
+                    <p class="w3-text-grey">
+                        <a class="w3-text-theme" href="{{ instance.url }}">
+                            {% blocktrans trimmed with number=instance.display_number %}View workflows for instance {{ number }}{% endblocktrans %}
+                        </a>
+                    </p>
+                {% endif %}
+            </header>
+            {% blocktrans trimmed with number=instance.display_number asvar response_caption %}Responses for instance {{ number }}{% endblocktrans %}
+            {% include "bones/partials/table.html" with table_headers=occurrence_response_headers table_rows=instance.response_rows table_caption=response_caption %}
+            {% blocktrans trimmed with number=instance.display_number asvar workflow_caption %}Workflows for instance {{ number }}{% endblocktrans %}
+            {% include "bones/partials/table.html" with table_headers=occurrence_workflow_headers table_rows=instance.workflow_rows table_caption=workflow_caption %}
+        </section>
+    {% endfor %}
+{% else %}
+    <section class="w3-section">
+        <p class="w3-text-grey">{% trans "No related workflows or responses were recorded for this occurrence." %}</p>
+    </section>
+{% endif %}

--- a/app/bones/tests/test_views_master_detail.py
+++ b/app/bones/tests/test_views_master_detail.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.test import RequestFactory, SimpleTestCase
 
@@ -49,3 +50,84 @@ class MasterDetailViewTests(SimpleTestCase):
         self.assertEqual(result, "—")
         formatted = CompletedTransectDetailView._format_coordinates(1.23, 4.56)
         self.assertIn("Lat", formatted)
+
+    def test_completed_occurrence_instance_summaries_grouped_by_instance(self):
+        class DummyManager:
+            def __init__(self, items):
+                self._items = list(items)
+
+            def all(self):
+                return list(self._items)
+
+        view = CompletedOccurrenceDetailView()
+        request = self.factory.get("/occurrences/42/")
+        view.setup(request, pk=42)
+
+        workflows = [
+            SimpleNamespace(
+                pk=1,
+                template_workflow=SimpleNamespace(name="Alpha"),
+                instance_number=1,
+                completed_by="Alice",
+            ),
+            SimpleNamespace(
+                pk=2,
+                template_workflow=SimpleNamespace(name="Beta"),
+                instance_number=2,
+                completed_by="Bob",
+            ),
+            SimpleNamespace(
+                pk=3,
+                template_workflow=SimpleNamespace(name="Alpha"),
+                instance_number=1,
+                completed_by="Cara",
+            ),
+        ]
+        responses = [
+            SimpleNamespace(
+                question_text="First question",
+                response="Answer one",
+                response_code="R1",
+                skipped=False,
+                workflow=workflows[0],
+                instance_number=1,
+            ),
+            SimpleNamespace(
+                question_text="Second question",
+                response="Answer two",
+                response_code="R2",
+                skipped=True,
+                workflow=workflows[1],
+                instance_number=2,
+            ),
+            SimpleNamespace(
+                question_text="Follow up",
+                response="Answer three",
+                response_code="R3",
+                skipped=False,
+                workflow=workflows[2],
+                instance_number=1,
+            ),
+        ]
+
+        view.object = SimpleNamespace(
+            pk=42,
+            responses=DummyManager(responses),
+            workflows=DummyManager(workflows),
+        )
+
+        with patch("bones.views.master_detail.safe_reverse", return_value="/workflows/"):
+            instance_summaries = view.get_instance_summaries()
+
+        self.assertEqual([summary["number"] for summary in instance_summaries], [1, 2])
+
+        instance_one = instance_summaries[0]
+        instance_two = instance_summaries[1]
+
+        self.assertEqual(len(instance_one["response_rows"]), 2)
+        self.assertEqual(len(instance_one["workflow_rows"]), 2)
+        self.assertEqual(instance_one["url"], "/workflows/?occurrence=42&instance_number=1")
+
+        self.assertEqual(len(instance_two["response_rows"]), 1)
+        self.assertEqual(len(instance_two["workflow_rows"]), 1)
+        self.assertEqual(instance_two["url"], "/workflows/?occurrence=42&instance_number=2")


### PR DESCRIPTION
## Summary
- extend the completed occurrence detail view to reuse response/workflow table formatting for instance-scoped data and build per-instance summaries
- replace the related items template to show instance-specific sections with links and graceful empty states
- cover the new instance summarisation helper with a unit test that validates grouping and link generation

## Testing
- python app/manage.py test bones.tests.test_views_master_detail

------
https://chatgpt.com/codex/tasks/task_e_68dd7d1d9c9c83298b65e83337cc4de0