### PR TITLE
Fix instance response filtering on completed occurrence detail

### DIFF
--- a/app/bones/templates/bones/completed_occurrences/_related.html
+++ b/app/bones/templates/bones/completed_occurrences/_related.html
@@ -1,21 +1,28 @@
 {% load i18n %}
-<section class="w3-section">
-    <header class="w3-margin-bottom">
-        <h3 class="w3-large w3-margin-0">
-            <span class="fa-fw fa-solid fa-list-check" aria-hidden="true"></span>
-            {% trans "Responses" %}
-        </h3>
-        <p class="w3-text-grey">{% trans "All responses collected for this occurrence." %}</p>
-    </header>
-    {% include "bones/partials/table.html" with table_headers=occurrence_response_headers table_rows=occurrence_response_rows table_caption=_('Occurrence responses') %}
-</section>
-<section class="w3-section">
-    <header class="w3-margin-bottom">
-        <h3 class="w3-large w3-margin-0">
-            <span class="fa-fw fa-solid fa-diagram-project" aria-hidden="true"></span>
-            {% trans "Workflows" %}
-        </h3>
-        <p class="w3-text-grey">{% trans "Completed workflows linked to this occurrence." %}</p>
-    </header>
-    {% include "bones/partials/table.html" with table_headers=occurrence_workflow_headers table_rows=occurrence_workflow_rows table_caption=_('Occurrence workflows') %}
-</section>
+{% if occurrence_instances %}
+    {% for instance in occurrence_instances %}
+        <section class="w3-section">
+            <header class="w3-margin-bottom">
+                <h3 class="w3-large w3-margin-0">
+                    <span class="fa-fw fa-solid fa-layer-group" aria-hidden="true"></span>
+                    {% blocktrans trimmed with number=instance.display_number %}Instance {{ number }}{% endblocktrans %}
+                </h3>
+                {% if instance.url %}
+                    <p class="w3-text-grey">
+                        <a class="w3-text-theme" href="{{ instance.url }}">
+                            {% blocktrans trimmed with number=instance.display_number %}View workflows for instance {{ number }}{% endblocktrans %}
+                        </a>
+                    </p>
+                {% endif %}
+            </header>
+            {% blocktrans trimmed with number=instance.display_number asvar response_caption %}Responses for instance {{ number }}{% endblocktrans %}
+            {% include "bones/partials/table.html" with table_headers=occurrence_response_headers table_rows=instance.response_rows table_caption=response_caption %}
+            {% blocktrans trimmed with number=instance.display_number asvar workflow_caption %}Workflows for instance {{ number }}{% endblocktrans %}
+            {% include "bones/partials/table.html" with table_headers=occurrence_workflow_headers table_rows=instance.workflow_rows table_caption=workflow_caption %}
+        </section>
+    {% endfor %}
+{% else %}
+    <section class="w3-section">
+        <p class="w3-text-grey">{% trans "No related workflows or responses were recorded for this occurrence." %}</p>
+    </section>
+{% endif %}

--- a/app/bones/tests/test_views_master_detail.py
+++ b/app/bones/tests/test_views_master_detail.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.test import RequestFactory, SimpleTestCase
 
@@ -49,3 +50,99 @@ class MasterDetailViewTests(SimpleTestCase):
         self.assertEqual(result, "—")
         formatted = CompletedTransectDetailView._format_coordinates(1.23, 4.56)
         self.assertIn("Lat", formatted)
+
+    def test_completed_occurrence_instance_summaries_grouped_by_instance(self):
+        class DummyManager:
+            def __init__(self, items):
+                self._items = list(items)
+
+            def all(self):
+                return list(self._items)
+
+        view = CompletedOccurrenceDetailView()
+        request = self.factory.get("/occurrences/42/")
+        view.setup(request, pk=42)
+
+        workflows = [
+            SimpleNamespace(
+                pk=1,
+                template_workflow=SimpleNamespace(name="Alpha"),
+                instance_number=1,
+                completed_by="Alice",
+            ),
+            SimpleNamespace(
+                pk=2,
+                template_workflow=SimpleNamespace(name="Beta"),
+                instance_number=2,
+                completed_by="Bob",
+            ),
+            SimpleNamespace(
+                pk=3,
+                template_workflow=SimpleNamespace(name="Alpha"),
+                instance_number=1,
+                completed_by="Cara",
+            ),
+        ]
+        responses = [
+            SimpleNamespace(
+                question_number=2,
+                question_text="Second question",
+                response="Answer two",
+                response_code="R2",
+                skipped=False,
+                workflow=workflows[0],
+            ),
+            SimpleNamespace(
+                question_number=1,
+                question_text="First question",
+                response="Answer one",
+                response_code="R1",
+                skipped=False,
+                workflow=workflows[2],
+            ),
+            SimpleNamespace(
+                question_number=1,
+                question_text="Beta question",
+                response="Answer beta",
+                response_code="R4",
+                skipped=False,
+                workflow=workflows[1],
+            ),
+            SimpleNamespace(
+                question_number=2,
+                question_text="Skipped question",
+                response="Should hide",
+                response_code="R5",
+                skipped=True,
+                workflow=workflows[1],
+            ),
+        ]
+
+        view.object = SimpleNamespace(
+            pk=42,
+            responses=DummyManager(responses),
+            workflows=DummyManager(workflows),
+        )
+
+        with patch("bones.views.master_detail.safe_reverse", return_value="/workflows/"):
+            instance_summaries = view.get_instance_summaries()
+
+        self.assertEqual([summary["number"] for summary in instance_summaries], [1, 2])
+        self.assertNotIn("—", [summary["display_number"] for summary in instance_summaries])
+
+        instance_one = instance_summaries[0]
+        instance_two = instance_summaries[1]
+
+        self.assertEqual(len(instance_one["response_rows"]), 2)
+        self.assertEqual(len(instance_one["workflow_rows"]), 2)
+        self.assertEqual(instance_one["url"], "/workflows/?occurrence=42&instance_number=1")
+
+        self.assertEqual(len(instance_two["response_rows"]), 1)
+        self.assertEqual(len(instance_two["workflow_rows"]), 1)
+        self.assertEqual(instance_two["url"], "/workflows/?occurrence=42&instance_number=2")
+
+        instance_one_question_order = [row[0]["value"] for row in instance_one["response_rows"]]
+        self.assertEqual(instance_one_question_order, ["First question", "Second question"])
+
+        instance_two_questions = [row[0]["value"] for row in instance_two["response_rows"]]
+        self.assertEqual(instance_two_questions, ["Beta question"])

--- a/app/bones/views/master_detail.py
+++ b/app/bones/views/master_detail.py
@@ -1,7 +1,8 @@
 """Master-detail view archetypes for completed records."""
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlencode
 
 from django.db import DatabaseError
 from django.utils.translation import gettext_lazy as _
@@ -432,7 +433,38 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
             )
         return headers, rows
 
-    def get_response_table(self) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]]]:
+    @staticmethod
+    def _resolve_instance_number(entry: Any) -> Any:
+        value = getattr(entry, "instance_number", None)
+        if value is not None:
+            return value
+        workflow = getattr(entry, "workflow", None)
+        if workflow is not None:
+            return getattr(workflow, "instance_number", None)
+        return None
+
+    @staticmethod
+    def _sort_responses(entries: Sequence[Any]) -> list[Any]:
+        def _sort_key(response: Any) -> tuple[Any, Any, Any]:
+            workflow = getattr(response, "workflow", None)
+            template_workflow = getattr(workflow, "template_workflow", None)
+            workflow_name = getattr(template_workflow, "name", None)
+            if workflow_name is None:
+                workflow_name = getattr(workflow, "name", None)
+            if workflow_name is None:
+                workflow_name = getattr(workflow, "pk", "")
+            question_number = getattr(response, "question_number", None)
+            question_text = getattr(response, "question_text", "")
+            return (str(workflow_name).lower(), question_number if question_number is not None else float("inf"), question_text)
+
+        return sorted(entries, key=_sort_key)
+
+    def get_response_table(
+        self,
+        responses: Iterable[Any] | None = None,
+        *,
+        instance_number: Any | None = None,
+    ) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]]]:
         headers = [
             {"label": _("Question")},
             {"label": _("Response")},
@@ -441,8 +473,19 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
             {"label": _("Workflow")},
         ]
         rows: list[list[dict[str, Any]]] = []
-        responses = getattr(self.object, "responses", None)
-        response_entries = responses.all() if hasattr(responses, "all") else []
+        response_source = responses
+        if response_source is None:
+            response_source = getattr(self.object, "responses", None)
+        response_entries = [
+            entry for entry in self._as_list(response_source) if not getattr(entry, "skipped", False)
+        ]
+        if instance_number is not None:
+            response_entries = [
+                entry
+                for entry in response_entries
+                if self._resolve_instance_number(entry) == instance_number
+            ]
+        response_entries = self._sort_responses(response_entries)
         for response in response_entries:
             workflow = getattr(response, "workflow", None)
             template_workflow = getattr(workflow, "template_workflow", None)
@@ -465,15 +508,28 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
             )
         return headers, rows
 
-    def get_workflow_table(self) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]]]:
+    def get_workflow_table(
+        self,
+        workflows: Iterable[Any] | None = None,
+        *,
+        instance_number: Any | None = None,
+    ) -> tuple[list[dict[str, Any]], list[list[dict[str, Any]]]]:
         headers = [
             {"label": _("Template workflow")},
             {"label": _("Instance")},
             {"label": _("Completed by")},
         ]
         rows: list[list[dict[str, Any]]] = []
-        workflows = getattr(self.object, "workflows", None)
-        workflow_entries = workflows.all() if hasattr(workflows, "all") else []
+        workflow_source = workflows
+        if workflow_source is None:
+            workflow_source = getattr(self.object, "workflows", None)
+        workflow_entries = self._as_list(workflow_source)
+        if instance_number is not None:
+            workflow_entries = [
+                entry
+                for entry in workflow_entries
+                if getattr(entry, "instance_number", None) == instance_number
+            ]
         for workflow in workflow_entries:
             workflow_pk = getattr(workflow, "pk", None)
             rows.append(
@@ -490,6 +546,63 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
                 ]
             )
         return headers, rows
+
+    def get_instance_summaries(
+        self,
+        *,
+        workflows: Iterable[Any] | None = None,
+        responses: Iterable[Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        workflow_entries = self._as_list(workflows if workflows is not None else getattr(self.object, "workflows", None))
+        response_entries = self._as_list(responses if responses is not None else getattr(self.object, "responses", None))
+
+        instance_order: list[Any] = []
+
+        def _record_instance(value: Any) -> None:
+            if value is None:
+                return
+            if value not in instance_order:
+                instance_order.append(value)
+
+        for workflow in workflow_entries:
+            _record_instance(getattr(workflow, "instance_number", None))
+        for response in response_entries:
+            _record_instance(self._resolve_instance_number(response))
+
+        instance_order.sort()
+
+        summaries: list[dict[str, Any]] = []
+        base_url = safe_reverse("workflows:list")
+        occurrence_pk = getattr(self.object, "pk", None)
+
+        for instance_number in instance_order:
+            _, workflow_rows = self.get_workflow_table(
+                workflow_entries,
+                instance_number=instance_number,
+            )
+            _, response_rows = self.get_response_table(
+                response_entries,
+                instance_number=instance_number,
+            )
+            url: str | None = None
+            if base_url and occurrence_pk is not None and instance_number is not None:
+                query = urlencode({
+                    "occurrence": occurrence_pk,
+                    "instance_number": instance_number,
+                })
+                url = f"{base_url}?{query}"
+
+            summaries.append(
+                {
+                    "number": instance_number,
+                    "display_number": format_value(instance_number),
+                    "workflow_rows": workflow_rows,
+                    "response_rows": response_rows,
+                    "url": url,
+                }
+            )
+
+        return summaries
 
     def get_history_entries(self) -> list[Any]:
         try:
@@ -526,9 +639,15 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         detail_headers, detail_rows = self.get_detail_table()
-        response_headers, response_rows = self.get_response_table()
-        workflow_headers, workflow_rows = self.get_workflow_table()
+        workflows = self._as_list(getattr(self.object, "workflows", None))
+        responses = self._as_list(getattr(self.object, "responses", None))
+        response_headers, response_rows = self.get_response_table(responses=responses)
+        workflow_headers, workflow_rows = self.get_workflow_table(workflows=workflows)
         history_entries = self.get_history_entries()
+        occurrence_instances = self.get_instance_summaries(
+            workflows=workflows,
+            responses=responses,
+        )
         context.update(
             {
                 "overview_sections": self.get_overview_sections(),
@@ -538,6 +657,7 @@ class CompletedOccurrenceDetailView(BonesMasterDetailView):
                 "occurrence_response_rows": response_rows,
                 "occurrence_workflow_headers": workflow_headers,
                 "occurrence_workflow_rows": workflow_rows,
+                "occurrence_instances": occurrence_instances,
                 "occurrence_history_entries": history_entries,
                 "occurrence_history_error": self.history_error,
             }


### PR DESCRIPTION
## Summary
- resolve response instance numbers via their workflows, filter out skipped entries, and sort rows by workflow then question number
- exclude missing instance numbers from summaries while keeping workflow links and instance ordering stable
- expand the view helper test to cover the new response filtering, ordering, and display expectations

## Testing
- python app/manage.py test bones.tests.test_views_master_detail

------
https://chatgpt.com/codex/tasks/task_e_68dd7d1d9c9c83298b65e83337cc4de0