### PR TITLE
Enforce Unix line endings for Docker shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
## What changed

- add `.gitattributes`
- force every `*.sh` file to be checked out with Unix LF line endings

## Why

On Windows, Git checked `app/scripts/entrypoint.sh` out with CRLF endings. The Linux container's `/bin/sh` then interpreted the carriage return as part of the `set` option and failed with:

```
./scripts/entrypoint.sh: 2: set: Illegal option -
```

The shell scripts were already stored with LF in Git, so the durable fix is an explicit checkout rule rather than another content-only normalization commit.

## Impact

Docker entrypoint scripts remain executable by `/bin/sh` even when the repository is cloned or checked out on Windows.

## Validation

- verified the failing worktree bytes contained `0D 0A`
- normalized both entrypoint scripts locally to `0A`
- validated both scripts with the container's actual `/bin/sh -n`
- `git diff --check` passed