### PR TITLE
Configure weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /app
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Kyiv
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    labels:
+      - dependencies
+      - python
+    commit-message:
+      prefix: deps
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:15"
+      timezone: Europe/Kyiv
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /app
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Europe/Kyiv
+    open-pull-requests-limit: 2
+    labels:
+      - dependencies
+    commit-message:
+      prefix: docker
+    groups:
+      docker-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- schedule weekly grouped Python dependency updates
- schedule weekly grouped GitHub Actions updates
- schedule weekly grouped Docker base-image updates
- keep Python major upgrades separate for deliberate review
- use existing dependency labels and conservative PR limits

## Validation
- configuration structure sanity check passed
- whitespace validation passed