### PR TITLE
Finish validated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,11 @@ updates:
       - dependencies
     commit-message:
       prefix: docker
+    ignore:
+      - dependency-name: python
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       docker-images:
         patterns:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,9 +9,9 @@ python-dotenv>=1.0
 # Third-party integrations for history tracking and enhanced widgets
 django-simple-history==3.13.0
 django-select2==8.4.8
-django-filter==23.5
+django-filter==26.1
 Pillow>=12.3.0,<13
-openpyxl>=3.1,<4
+openpyxl>=3.1.5,<4
 #certifi==2021.10.8
 #cffi==1.15.0
 #charset-normalizer==2.0.12


### PR DESCRIPTION
## Summary
- upgrade django-filter to 26.1
- raise the openpyxl lower bound to 3.1.5
- prevent automatic Python Docker runtime minor and major jumps
- supersede conflicted Dependabot PRs #47 and #48

## Validation
- 261 Django tests passed
- Django system and deployment checks passed with warnings only
- Ruff correctness checks passed
- Python compilation passed
- pip check passed