### PR TITLE
Complete routine dependency refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       - python
     commit-message:
       prefix: deps
+    ignore:
+      - dependency-name: Django
+        update-types:
+          - version-update:semver-major
     groups:
       python-minor-and-patch:
         patterns:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,11 +1,11 @@
 Django==5.2.16
-asgiref>=3.5.2
+asgiref>=3.12.1
 sqlparse==0.6.0
 debugpy==1.8.21
-gunicorn==22.0.0
-mssql-django>=1.4
+gunicorn==26.0.0
+mssql-django>=1.8.0
 pyodbc>=5.3.0
-python-dotenv>=1.0
+python-dotenv>=1.2.3
 # Third-party integrations for history tracking and enhanced widgets
 django-simple-history==3.13.0
 django-select2==8.4.8


### PR DESCRIPTION
## Summary
- upgrade gunicorn, asgiref, mssql-django, and python-dotenv
- retain Django 5.2 on the supported Python 3.10 runtime
- suppress unsupported Django major proposals until the runtime is upgraded
- supersede Dependabot PRs #50, #51, #52, and #54

## Validation
- 261 Django tests passed
- Django system and deployment checks passed with warnings only
- Ruff correctness checks passed
- Python compilation passed
- pip check passed