### PR TITLE
Add pull request dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: [main, staging, prod]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,8 @@ The main branch is protected. For changes intended for main:
 3. Commit only the reviewed files and push that branch.
 4. Open a pull request targeting main.
 5. Wait for the required "Django checks and tests", "Docker image build and
-   tests", and "CodeQL" status checks to pass, and update the branch if GitHub
-   reports it is behind main.
+   tests", "CodeQL", and "Dependency review" status checks to pass, and update
+   the branch if GitHub reports it is behind main.
 6. Resolve all review conversations before merging.
 
 The repository requires a pull request but does not require an approving review,


### PR DESCRIPTION
## Summary
- add a SHA-pinned dependency review workflow for pull requests
- block newly introduced high or critical dependency vulnerabilities
- run with read-only permissions and bounded execution
- document the new required check in AGENTS.md

## Follow-up configuration
- make Dependency review required after its first successful run