### PR TITLE
Add community contribution guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default ownership. Approval is intentionally not required while the project
+# has a single maintainer; this mapping provides review visibility and a clear
+# place to add component owners later.
+* @karilint

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a reproducible problem in Bones
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Do not include secrets, private database
+        records, or vulnerability details in this public issue.
+  - type: input
+    id: version
+    attributes:
+      label: Bones version
+      description: Release, image digest, or commit SHA where the problem occurs.
+      placeholder: v1.0.0 or f71f62e
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem
+      description: What happened, and what impact does it have?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest deterministic sequence that reproduces it.
+      placeholder: |
+        1. Open ...
+        2. Filter by ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Local development
+        - Staging
+        - Production
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized diagnostics
+      description: Add relevant logs, traceback, browser, OS, and database driver details.
+      render: shell
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Data and security checks
+      options:
+        - label: I removed credentials, personal data, and private field records.
+          required: true
+        - label: This is not a security vulnerability requiring private reporting.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/karilint/bones/security/advisories/new
+    about: Report suspected vulnerabilities privately to the maintainer.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a focused improvement to Bones
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or need
+      description: Describe the user or operational need, not only a proposed implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What should users be able to do when this is complete?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: Include relevant pages, workflows, filters, or deployment behavior.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope checks
+      options:
+        - label: I searched existing issues for the same request.
+          required: true
+        - label: I have not included secrets, personal data, or private field records.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- Explain the outcome and why the change is needed. -->
+
+## Related issue
+
+<!-- Use "Closes #123" when applicable. -->
+
+## Validation
+
+<!-- List the exact checks run and their results. -->
+
+- [ ] Relevant Django checks and tests pass.
+- [ ] Container validation passes when runtime or dependencies changed.
+- [ ] I documented anything that could not be verified locally.
+
+## User-facing evidence
+
+<!-- Add sanitized screenshots or output for visible changes, or write "Not applicable". -->
+
+## Checklist
+
+- [ ] The change is focused and follows the existing Bones architecture.
+- [ ] Tests cover changed behavior without requiring a live production database.
+- [ ] Documentation and release notes are updated when needed.
+- [ ] No credentials, personal data, private field records, or `.env` contents are included.
+- [ ] Database changes account for unmanaged SQL Server tables.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,13 +2,14 @@
 
 ## Supported Versions
 
-Bones does not currently publish versioned releases. Security fixes are applied
-to the latest code on the `main` branch only.
+Security fixes are developed on `main` and released for the current major
+version when users need an updated deployable artifact.
 
 | Version | Supported |
 | --- | --- |
-| `main` | Yes |
-| Older commits and branches | No |
+| `1.x` | Yes |
+| `main` | Development |
+| `< 1.0` | No |
 
 ## Reporting a Vulnerability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Bones
+
+Thank you for helping improve Bones. Keep changes focused, explain their user
+impact, and follow the existing Django architecture documented in
+[`AGENTS.md`](AGENTS.md), [`docs/architecture.md`](docs/architecture.md), and
+[`docs/django_app_guidelines.md`](docs/django_app_guidelines.md).
+
+## Before opening an issue
+
+- Use the bug or feature issue form and search existing issues first.
+- Do not disclose vulnerabilities publicly. Follow
+  [the security policy](.github/SECURITY.md) instead.
+- Include only sanitized examples; never attach credentials, `.env` contents,
+  private database records, or identifiable field data.
+
+## Development workflow
+
+1. Branch from the latest `main`; do not commit directly to `main`.
+2. Use Python 3.14 and install the locked CI dependencies:
+
+   ```powershell
+   python -m venv .venv
+   .\.venv\Scripts\Activate.ps1
+   python -m pip install --require-hashes -r app\requirements-ci.txt
+   ```
+
+3. Make a narrow change that follows the existing app, template, and test
+   patterns. SQL Server application tables are unmanaged; use the established
+   raw migration approach for production indexes and avoid schema assumptions.
+4. Add or update deterministic, offline-safe tests under `app/bones/tests/`.
+5. Run the relevant checks from the repository root:
+
+   ```powershell
+   $env:DEBUG='0'
+   .\.venv\Scripts\python.exe app\manage.py check
+   .\.venv\Scripts\python.exe app\manage.py test bones.tests
+   .\.venv\Scripts\python.exe -m ruff check --select E9,F63,F7,F82 app
+   ```
+
+6. Push the branch and open a pull request using the repository template.
+
+## Pull requests and commits
+
+- Keep each pull request reviewable and limited to one coherent outcome.
+- Describe validation and any behavior that could not be tested locally.
+- Keep required checks passing and update the branch when GitHub reports it as
+  behind `main`.
+- Do not rewrite public or shared history. `main` requires verified signatures
+  and linear history, and GitHub merges accepted pull requests by squash only.
+- Update user-facing documentation and release notes when behavior or
+  deployment requirements change.
+
+By contributing, you agree that your contribution is licensed under the
+repository's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Stable containers are published to `ghcr.io/karilint/bones` with version and
 source-commit tags. Production deployments should use an immutable version or
 commit tag rather than `latest`.
 
+## Contributing
+
+Bug reports and focused pull requests are welcome. Read
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the development workflow, required
+checks, data-safety expectations, and protected-branch rules. Report security
+issues privately according to [the security policy](.github/SECURITY.md).
+
 ## Prerequisites
 
 * Python 3.14


### PR DESCRIPTION
## Summary
- add contributor guidance, issue forms, a pull-request template, and CODEOWNERS
- route vulnerability reports to private security advisories and protect sensitive field data
- update README contribution links and the supported security release line

## Validation
- parsed and structurally validated all issue-template YAML files
- git diff --check

## User-facing evidence
Not applicable; documentation and repository metadata only.

## Checklist
- [x] The change is focused and follows the existing Bones architecture.
- [x] Tests are not required for documentation-only changes.
- [x] Documentation is updated.
- [x] No credentials, personal data, private field records, or .env contents are included.
- [x] No database changes are included.