### PR TITLE
Finalize GitHub security workflow

### DIFF
--- a/.github/allowed_signers
+++ b/.github/allowed_signers
@@ -1,0 +1,1 @@
+kari.lintulaakso@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPgUnGuuGJseW38E+SZUIKQrFDkOWavesLT49BXWm1h4 karilint/bones commit signing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,17 @@ jobs:
         run: python -m pip install --require-hashes -r app/requirements-ci.txt
 
       - name: Verify dependency locks
-        working-directory: app
         run: |
+          python -m unittest scripts.tests.test_verify_dependency_locks
+          cp app/requirements.txt "${RUNNER_TEMP}/requirements.txt"
+          cp app/requirements-ci.txt "${RUNNER_TEMP}/requirements-ci.txt"
+          pushd app
           python -m piptools compile --generate-hashes --strip-extras --quiet --output-file=requirements.txt requirements.in
           python -m piptools compile --allow-unsafe --generate-hashes --strip-extras --quiet --output-file=requirements-ci.txt requirements-ci.in
-          git diff --exit-code -- requirements.txt requirements-ci.txt
+          popd
+          python scripts/verify_dependency_locks.py \
+            "${RUNNER_TEMP}/requirements.txt" app/requirements.txt \
+            "${RUNNER_TEMP}/requirements-ci.txt" app/requirements-ci.txt
 
       - name: Check Python correctness
         run: ruff check --select E9,F63,F7,F82 app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,9 @@ When changing Django code, templates, filters, forms, navigation, or history:
   `pip-compile --allow-unsafe --generate-hashes --strip-extras` under Python
   3.14 whenever an input dependency changes. The CI lock includes its pinned
   bootstrap tooling so every installed package remains hash checked.
+- CI compares regenerated locks semantically. It tolerates only repeated
+  identical hash lines emitted by Dependabot; version, dependency, header, and
+  effective hash-set drift must fail validation.
 - The application image installs `requirements.txt`; GitHub CI installs
   `requirements-ci.txt`, which additionally includes Ruff.
 
@@ -205,8 +208,9 @@ When changing Django code, templates, filters, forms, navigation, or history:
 - Follow `docs/releases.md` for version and release work.
 - Keep `app/VERSION`, `CHANGELOG.md`, and `docs/releases/vX.Y.Z.md` aligned in
   the release pull request.
-- Create a release tag only from a commit contained in protected `main`, after
-  every required pull-request check has passed.
+- Create a signed release tag only from a commit contained in protected `main`,
+  after every required pull-request check has passed. Verify the signature
+  locally before pushing the tag.
 - Never move or reuse a published version tag. Prepare a new patch release for
   corrections.
 - Treat GHCR version and source-commit tags as deployment artifacts; do not use

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our standard
+
+Bones contributors and maintainers must provide a welcoming, respectful, and
+harassment-free environment. Be constructive, assume good intent, respect
+different experience levels and backgrounds, and focus criticism on ideas and
+changes rather than people.
+
+Unacceptable behavior includes harassment, discrimination, threats, personal
+attacks, deliberate intimidation, unwanted sexual attention, publishing
+another person's private information, or sustained disruption of project work.
+
+## Scope
+
+This standard applies in repository issues, pull requests, reviews, discussions,
+and other spaces where someone represents the Bones project.
+
+## Reporting and enforcement
+
+Report conduct concerns privately to the maintainer at
+<kari.lintulaakso@gmail.com>. Do not use a public issue when a report contains
+private or sensitive information. Reports will be reviewed promptly and kept
+confidential as far as reasonably possible.
+
+The maintainer may edit or remove contributions, comments, commits, code, or
+other material that violates this standard, and may temporarily or permanently
+restrict participation. Enforcement decisions will consider context, impact,
+and whether harmful behavior is repeated.
+
+Good-faith reports will not result in retaliation. Knowingly false or abusive
+reports may themselves be treated as a violation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,10 @@ python -m piptools compile --generate-hashes --strip-extras --output-file=requir
 python -m piptools compile --allow-unsafe --generate-hashes --strip-extras --output-file=requirements-ci.txt requirements-ci.in
 ```
 
-CI repeats these commands without upgrading already valid pins and fails when
-the generated files differ from the committed lock files.
+CI repeats these commands without upgrading already valid pins and fails on
+semantic lock drift. Repeated identical hashes emitted by Dependabot are
+accepted because they do not change the allowed artifacts; changed versions,
+dependencies, or hash sets still fail.
 
 ## Pull requests and commits
 
@@ -64,6 +66,10 @@ the generated files differ from the committed lock files.
   and linear history, and GitHub merges accepted pull requests by squash only.
 - Update user-facing documentation and release notes when behavior or
   deployment requirements change.
+- Sign local commits and release tags with the repository's configured signing
+  key. GitHub requires verified signatures on `main` and future release tags.
+  Maintainer public signing identities are recorded in
+  `.github/allowed_signers` for local verification.
 
 By contributing, you agree that your contribution is licensed under the
 repository's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Bug reports and focused pull requests are welcome. Read
 [`CONTRIBUTING.md`](CONTRIBUTING.md) for the development workflow, required
 checks, data-safety expectations, and protected-branch rules. Report security
 issues privately according to [the security policy](.github/SECURITY.md).
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Prerequisites
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,13 +18,23 @@ an entry in `CHANGELOG.md` and a notes file at `docs/releases/vX.Y.Z.md`.
 1. Create a release branch from current `main`.
 2. Update `app/VERSION`, `CHANGELOG.md`, and the versioned release-notes file.
 3. Merge the release pull request after all required checks pass.
-4. Create and push the matching `vX.Y.Z` tag at the merge commit.
+4. Create the matching signed `vX.Y.Z` tag at the merge commit and verify its
+   signature locally before pushing it:
+
+   ```bash
+   git tag -s vX.Y.Z -m "Bones vX.Y.Z"
+   git tag -v vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
 5. Wait for the `Release` workflow to verify the tag, rerun the application
    checks, publish the container, attest it, and create the GitHub release.
 
 The workflow rejects tags whose version differs from `app/VERSION`, tags that
-are not contained in `main`, and releases without versioned notes. Published
-tags must never be moved or reused; issue a new patch release instead.
+are not contained in `main`, and releases without versioned notes. Repository
+rules also reject unsigned release tags. Published tags must never be moved or
+reused; issue a new patch release instead. The original `v1.0.0` tag predates
+the signature requirement and remains immutable rather than being rewritten.
 
 ## Release artifacts
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance helpers."""

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for repository maintenance helpers."""

--- a/scripts/tests/test_verify_dependency_locks.py
+++ b/scripts/tests/test_verify_dependency_locks.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from scripts.verify_dependency_locks import compare_locks, normalize_lock
+
+
+LOCK = """\
+# generated lock
+ruff==0.16.3 \\
+    --hash=sha256:first \\
+    --hash=sha256:second
+    # via requirements-ci.in
+"""
+
+
+class NormalizeLockTests(TestCase):
+    def test_repeated_hash_for_same_package_is_ignored(self):
+        duplicated = LOCK.replace(
+            "    --hash=sha256:first \\\n",
+            "    --hash=sha256:first \\\n    --hash=sha256:first \\\n",
+        )
+
+        self.assertEqual(normalize_lock(LOCK), normalize_lock(duplicated))
+
+    def test_same_hash_in_separate_packages_is_preserved(self):
+        content = "one==1 \\\n    --hash=sha256:same\ntwo==2 \\\n    --hash=sha256:same\n"
+
+        self.assertEqual(normalize_lock(content).count("sha256:same"), 2)
+
+    def test_version_change_is_not_equivalent(self):
+        self.assertNotEqual(normalize_lock(LOCK), normalize_lock(LOCK.replace("0.16.3", "0.16.4")))
+
+    def test_missing_hash_is_not_equivalent(self):
+        self.assertNotEqual(
+            normalize_lock(LOCK),
+            normalize_lock(LOCK.replace("    --hash=sha256:second\n", "")),
+        )
+
+    def test_compare_locks_accepts_only_duplicate_hash_drift(self):
+        with TemporaryDirectory() as directory:
+            committed = Path(directory, "committed.txt")
+            generated = Path(directory, "generated.txt")
+            committed.write_text(LOCK + "    --hash=sha256:second\n", encoding="utf-8")
+            generated.write_text(LOCK, encoding="utf-8")
+
+            self.assertTrue(compare_locks(committed, generated))

--- a/scripts/verify_dependency_locks.py
+++ b/scripts/verify_dependency_locks.py
@@ -1,0 +1,62 @@
+"""Compare generated dependency locks while tolerating duplicate hashes."""
+
+from __future__ import annotations
+
+import difflib
+import sys
+from pathlib import Path
+
+
+def normalize_lock(content: str) -> str:
+    """Return a lock representation with repeated hashes removed per package."""
+    normalized: list[str] = []
+    package_hashes: set[str] = set()
+
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("--hash="):
+            if stripped in package_hashes:
+                continue
+            package_hashes.add(stripped)
+        elif line and not line[0].isspace() and not line.startswith("#"):
+            package_hashes.clear()
+        normalized.append(line)
+
+    return "\n".join(normalized) + "\n"
+
+
+def compare_locks(committed: Path, generated: Path) -> bool:
+    """Compare one committed/generated pair and print a useful diff on drift."""
+    committed_text = normalize_lock(committed.read_text(encoding="utf-8"))
+    generated_text = normalize_lock(generated.read_text(encoding="utf-8"))
+    if committed_text == generated_text:
+        return True
+
+    sys.stderr.writelines(
+        difflib.unified_diff(
+            committed_text.splitlines(keepends=True),
+            generated_text.splitlines(keepends=True),
+            fromfile=str(committed),
+            tofile=str(generated),
+        )
+    )
+    return False
+
+
+def main(arguments: list[str]) -> int:
+    """Compare committed/generated path pairs supplied on the command line."""
+    if not arguments or len(arguments) % 2:
+        print(
+            "usage: verify_dependency_locks.py COMMITTED GENERATED [...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    matches = True
+    for index in range(0, len(arguments), 2):
+        matches &= compare_locks(Path(arguments[index]), Path(arguments[index + 1]))
+    return 0 if matches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- keep deterministic dependency-lock checks while treating only duplicate identical Dependabot hashes as equivalent
- add tested lock comparison tooling and contributor guidance
- document and enforce signed future release tags with a tracked allowed-signers identity
- add the project Code of Conduct

## Live repository settings
- added an accurate repository description
- removed the empty unused copilot environment
- required signatures on future semantic-version tags while preserving immutable v1.0.0

## Validation
- five dependency-lock comparison unit tests
- full lock verification in pinned Python 3.14.7
- Python compilation, workflow YAML parsing, and git diff --check
- local commit and tag SSH signature verification

## Note
The commit is cryptographically signed. GitHub will mark it verified after its public key is registered as a Signing Key.